### PR TITLE
Add support for transforming nested components

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ $ npx ember-angle-brackets-codemod angle-brackets app/templates
     {{#s.option value=country}}{{country.name}}{{/s.option}}
   {{/each}}
 {{/super-select}}
+
+{{ui/button text="Click me"}}
 ```
 
 ## To
@@ -44,6 +46,8 @@ $ npx ember-angle-brackets-codemod angle-brackets app/templates
     </s.option>
   {{/each}}
 </SuperSelect>
+
+<Ui::Button @text="Click me" />
 ```
 
 ## AST Explorer playground

--- a/transforms/angle-brackets/__testFixtures__/nested.input.hbs
+++ b/transforms/angle-brackets/__testFixtures__/nested.input.hbs
@@ -1,0 +1,7 @@
+{{ui/site-header user=this.user class=(if this.user.isAdmin "admin")}}
+{{ui/button text="Click me"}}
+{{#some-path/another-path/super-select selected=this.user.country as |s|}}
+  {{#each this.availableCountries as |country|}}
+    {{#s.option value=country}}{{country.name}}{{/s.option}}
+  {{/each}}
+{{/some-path/another-path/super-select}}

--- a/transforms/angle-brackets/__testFixtures__/nested.output.hbs
+++ b/transforms/angle-brackets/__testFixtures__/nested.output.hbs
@@ -1,0 +1,9 @@
+<Ui::SiteHeader @user={{this.user}} class={{if this.user.isAdmin "admin"}} />
+<Ui::Button @text="Click me" />
+<SomePath::AnotherPath::SuperSelect @selected={{this.user.country}} as |s|>
+  {{#each this.availableCountries as |country|}}
+    <s.option @value={{country}}>
+      {{country.name}}
+    </s.option>
+  {{/each}}
+</SomePath::AnotherPath::SuperSelect>

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -41,6 +41,23 @@ const capitalizedTagName = tagname => {
     .join("");
 };
 
+const transformTagName = tagName => {
+  if (tagName.includes('.')) {
+    return tagName;
+  }
+
+  if (tagName.includes('/')) {
+    return transformNestedTagName(tagName);
+  }
+
+  return capitalizedTagName(tagName)
+};
+
+const transformNestedTagName = tagName => {
+  const paths = tagName.split('/');
+  return paths.map(name => capitalizedTagName(name)).join('::');
+};
+
 /**
  * exports
  *
@@ -128,7 +145,7 @@ const transformLinkToAttrs = params => {
       const isValidMustache = node.loc.source !== "(synthetic)" && !IGNORE_MUSTACHE_STATEMENTS.includes(node.path.original);
       if (isValidMustache && node.hash.pairs.length > 0) {
         const tagName = node.path.original;
-        const newTagName = tagName.includes('.') ? tagName : capitalizedTagName(tagName);
+        const newTagName = transformTagName(tagName);
         const attributes = transformAttrs(node.hash.pairs);
 
         return b.element(
@@ -153,7 +170,7 @@ const transformLinkToAttrs = params => {
         } else {
           attributes = transformAttrs(node.hash.pairs);
         }
-        const newTagName = tagName.includes('.') ? tagName : capitalizedTagName(tagName);
+        const newTagName = transformTagName(tagName);
 
         return b.element(newTagName, {
           attrs: attributes,


### PR DESCRIPTION
Support the new nested component syntax

### Before
```hbs
{{ui/site-header user=this.user class=(if this.user.isAdmin "admin")}}
{{ui/button text="Click me"}}
{{#some-path/another-path/super-select selected=this.user.country as |s|}}
  {{#each this.availableCountries as |country|}}
    {{#s.option value=country}}{{country.name}}{{/s.option}}
  {{/each}}
{{/some-path/another-path/super-select}}
```

### After
```hbs
<Ui::SiteHeader @user={{this.user}} class={{if this.user.isAdmin "admin"}} />
<Ui::Button @text="Click me" />
<SomePath::AnotherPath::SuperSelect @selected={{this.user.country}} as |s|>
  {{#each this.availableCountries as |country|}}
    <s.option @value={{country}}>
      {{country.name}}
    </s.option>
  {{/each}}
</SomePath::AnotherPath::SuperSelect>
```