### PR TITLE
support nested subexpressions with named args

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.input.hbs
@@ -3,8 +3,16 @@
 {{/some-component}}
 {{deep-component class=(concat foo (nice-helper ted (some-crazy bar (a d (d e f)))))}}
 {{some-component
-    class=(concat foo (some-helper bar))
+  class=(concat foo (some-helper bar))
 }}
 {{some-component
-    class=(concat foo (some-helper bar quuz))
+  class=(concat foo (some-helper bar quuz))
+}}
+{{some-component person=(hash name="Sophie" age=1)}}
+{{some-component
+  people=(array
+    (hash name="Alex" age=5 nested=(hash oldest=true))
+    (hash name="Ben" age=4)
+    (hash name="Sophie" age=1)
+  )
 }}

--- a/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.output.hbs
@@ -10,8 +10,8 @@
 <SomeComponent @person={{hash name="Sophie" age=1}} />
 <SomeComponent
   @people={{array
-    (hash name=Alex age=5 nested=(hash oldest=true))
-    (hash name=Ben age=4)
-    (hash name=Sophie age=1)
+    (hash name="Alex" age=5 nested=(hash oldest=true))
+    (hash name="Ben" age=4)
+    (hash name="Sophie" age=1)
   }}
  />

--- a/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.output.hbs
@@ -7,3 +7,11 @@
 
 <SomeComponent class={{concat foo (some-helper bar)}} />
 <SomeComponent class={{concat foo (some-helper bar quuz)}} />
+<SomeComponent @person={{hash name="Sophie" age=1}} />
+<SomeComponent
+  @people={{array
+    (hash name=Alex age=5 nested=(hash oldest=true))
+    (hash name=Ben age=4)
+    (hash name=Sophie age=1)
+  }}
+ />

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -72,6 +72,9 @@ const transformNestedSubExpression = subExpression => {
         let nestedValue = transformNestedSubExpression(pair.value);
         return `${pair.key}=${nestedValue}`;
       } else {
+        if(pair.value.type === "StringLiteral") {
+          return `${pair.key}="${pair.value.original}"`;
+        }
         return `${pair.key}=${pair.value.original}`;
       }
     });

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -63,13 +63,29 @@ const transformNestedTagName = tagName => {
   return paths.map(name => capitalizedTagName(name)).join('::');
 };
 
-const nestedSubEx = p => {
-  return "(" + p.path.original + " " + p.params.map(p => {
-    if (p.type === "SubExpression") {
-      return nestedSubEx(p)
-    }
-    return p.original
-  }).join(" ") + ")";
+const transformNestedSubExpression = subExpression => {
+  let values;
+
+  if (subExpression.hash.pairs.length > 0) { //hash eg. `(hash name="Ben")`
+    values = subExpression.hash.pairs.map(pair => {
+      if (pair.value.type === "SubExpression") {
+        let nestedValue = transformNestedSubExpression(pair.value);
+        return `${pair.key}=${nestedValue}`;
+      } else {
+        return `${pair.key}=${pair.value.original}`;
+      }
+    });
+  } else { //params eg. `(add 1 2)`
+    values = subExpression.params.map(param => {
+      if (param.type === "SubExpression") {
+        return transformNestedSubExpression(param);
+      } else {
+        return param.original;
+      }
+    });
+  }
+
+  return `(${subExpression.path.original} ${values.join(" ")})`;
 }
 
 /**
@@ -88,6 +104,7 @@ module.exports = function(fileInfo, api, options) {
    * Transform the attributes names & values properly 
    */
   const transformAttrs = attrs => {
+
     return attrs.map(a => {
       let _key = a.key;
       let _valueType = a.value.type;
@@ -99,18 +116,21 @@ module.exports = function(fileInfo, api, options) {
       if (_valueType === "PathExpression") {
         _value = b.mustache(b.path(a.value.original));
       } else if (_valueType === "SubExpression") {
+        if (a.value.hash.pairs.length > 0) {
+          _value = b.mustache(a.value.path.original, [], a.value.hash)
+        } else {
+          const params = a.value.params.map(p => {
+            if(p.type === "SubExpression") {
+              return transformNestedSubExpression(p)
+            } else if(p.type === "StringLiteral") {
+              return  `"${p.original}"` ;
+            } else {
+              return p.original
+            }
+          }).join(" ");
 
-        const params = a.value.params.map(p => {
-          if(p.type === "SubExpression") {
-            return nestedSubEx(p)
-          } else if(p.type === "StringLiteral") {
-            return  `"${p.original}"` ;
-          } else {
-            return p.original
-          }
-        }).join(" ");
-
-        _value = b.mustache(b.path(a.value.path.original + " " + params));
+          _value = b.mustache(b.path(a.value.path.original + " " + params));
+        }
 
       } else if(_valueType === "BooleanLiteral") {
        _value = b.mustache(b.boolean(a.value.original))


### PR DESCRIPTION
towards https://github.com/rajasegar/ember-angle-brackets-codemod/issues/24

**input:**

```hbs
{{some-component person=(hash name="Sophie" age=1)}}
{{some-component
  people=(array
    (hash name="Alex" age=5 nested=(hash oldest=true))
    (hash name="Ben" age=4)
    (hash name="Sophie" age=1)
  )
}}
```

**output:** (edit: updated to include double quotes)

```hbs
<SomeComponent @person={{hash name="Sophie" age=1}} />
<SomeComponent
  @people={{array
    (hash name="Alex" age=5 nested=(hash oldest=true))
    (hash name="Ben" age=4)
    (hash name="Sophie" age=1)
  }}
 />
```