### PR TITLE
Support optional config file containing list of helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To help the codemod disambiguate components and helpers, you can define a list o
   ]
 }
 ```
-
+The codemod will then ignore the above list of helpers and prevent them from being transformed into the new (angle-brackets) syntax.
 And then execute the codemod as follows:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ $ npx ember-angle-brackets-codemod angle-brackets app/templates
 <Ui::Button @text="Click me" />
 ```
 
+## Advanced Usage
+
+To help the codemod disambiguate components and helpers, you can define a list of helpers from your application in a configuration file as follows:
+
+**config/anglebrackets-codemod-config.json**
+
+```js
+{
+  "helpers": [
+    "date-formatter", 
+    "info-pill"
+  ]
+}
+```
+
+And then execute the codemod as follows:
+
+```sh
+$ cd my-ember-app-or-addon
+$ npx ember-angle-brackets-codemod angle-brackets app/templates --config ./config/anglebrackets-codemod-config.json
+```
+
 ## AST Explorer playground
 
 1. Go to the [AST Explorer](https://astexplorer.net/#/gist/b128d5545d7ccc52400b922f3b5010b4/642c6a8d3cc021257110bcf6b1714d1065891aec)

--- a/transforms/-preset.js
+++ b/transforms/-preset.js
@@ -2,12 +2,14 @@
 
 const path = require('path');
 const fs = require('fs');
+const { getOptions } = require('codemod-cli');
 
 module.exports = function(type) {
   let transformPath = path.join(__dirname, type, 'transforms');
 
-  return function(file, api, options) {
+  return function(file, api) {
     let src = file.source;
+    let options = getOptions();
     let error;
 
     fs.readdirSync(transformPath)

--- a/transforms/angle-brackets/__testfixtures__/custom-options.config.json
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.config.json
@@ -1,0 +1,3 @@
+{
+  "helpers": ["some-helper1", "some-helper2", "some-helper3"]
+}

--- a/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
@@ -1,0 +1,3 @@
+{{some-component foo=true}}
+{{some-helper1 foo=true}}
+{{some-helper2 foo=true}}

--- a/transforms/angle-brackets/__testfixtures__/custom-options.options.json
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.options.json
@@ -1,0 +1,3 @@
+{
+  "config": "./transforms/angle-brackets/__testfixtures__/custom-options.config.json"
+}

--- a/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
@@ -1,0 +1,3 @@
+<SomeComponent @foo={{true}} />
+{{some-helper1 foo=true}}
+{{some-helper2 foo=true}}


### PR DESCRIPTION
part of https://github.com/rajasegar/ember-angle-brackets-codemod/issues/12

This PR adds support for an optional `--config` argument:

`npx ember-angle-brackets-codemod angle-brackets app/templates --config ./config/anglebrackets-codemod-config.json`

This config file initially supports providing a list of helpers to help the codemod to disambiguate from components, eg:

```json
{
  "helpers": ["ic-interface-icon", "date-formatter"]
}
```

While this isn't the perfect solution (it would be great if we could auto detect this information), it it good enough to unblock my attempts to use this codemod on my large ember app so I think it's worth landing.

Useful links:

 * Here's where the options are set: https://github.com/rwjblue/codemod-cli/blob/3dd1e8e9496ea008cdcfbfa8f9191ee53460f372/src/bin-support.js#L23

