### PR TITLE
Add failing test for losing positional param

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/positional-params.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/positional-params.input.hbs
@@ -1,0 +1,8 @@
+{{#vertical-collection
+    items
+    tagName='ul'
+    estimateHeight=50 as |item i|}}
+    <li>
+      {{item.number}} {{i}}
+    </li>
+{{/vertical-collection}}

--- a/transforms/angle-brackets/__testfixtures__/positional-params.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/positional-params.output.hbs
@@ -1,0 +1,6 @@
+<VerticalCollection items @tagName="ul" @estimateHeight="50" as |item i|>
+  <li>
+    {{item.number}}
+    {{i}}
+  </li>
+</VerticalCollection>


### PR DESCRIPTION
Failing test for #36, it loses the `items` positional param. 