### PR TITLE
add `skipBuiltInComponents` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,20 @@ To help the codemod disambiguate components and helpers, you can define a list o
   ]
 }
 ```
-The codemod will then ignore the above list of helpers and prevent them from being transformed into the new (angle-brackets) syntax.
-And then execute the codemod as follows:
+The codemod will then ignore the above list of helpers and prevent them from being transformed into the new angle-brackets syntax.
+
+You can also disable the conversion of the built-in components `{{link-to}}`, `{{input}}` and `{{textarea}}` as follows:
+
+**config/anglebrackets-codemod-config.json**
+
+```js
+{
+  "helpers": [],
+  "skipBuiltInComponents": true
+}
+```
+
+You can execute the codemod with custom configuration by specifying a `--config` command line option as follows:
 
 ```sh
 $ cd my-ember-app-or-addon

--- a/transforms/angle-brackets/__testfixtures__/custom-options.config.json
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.config.json
@@ -1,3 +1,4 @@
 {
-  "helpers": ["some-helper1", "some-helper2", "some-helper3"]
+  "helpers": ["some-helper1", "some-helper2", "some-helper3"],
+  "skipBuiltInComponents": true
 }

--- a/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.input.hbs
@@ -1,3 +1,6 @@
 {{some-component foo=true}}
 {{some-helper1 foo=true}}
 {{some-helper2 foo=true}}
+{{link-to "Title" "some.route"}}
+{{textarea value=this.model.body}}
+{{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}

--- a/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options.output.hbs
@@ -1,3 +1,6 @@
 <SomeComponent @foo={{true}} />
 {{some-helper1 foo=true}}
 {{some-helper2 foo=true}}
+{{link-to "Title" "some.route"}}
+{{textarea value=this.model.body}}
+{{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -8,14 +8,17 @@ const _EMPTY_STRING_ = `ANGLE_BRACKET_EMPTY_${Date.now()}`;
 class Config {
   constructor(options) {
     this.helpers = [];
+    this.skipBuiltInComponents = false;
 
     if (options.config) {
       let filePath = path.join(process.cwd(), options.config);
-      let data = JSON.parse(fs.readFileSync(filePath));
+      let config = JSON.parse(fs.readFileSync(filePath));
 
-      if (data.helpers) {
-        this.helpers = data.helpers;
+      if (config.helpers) {
+        this.helpers = config.helpers;
       }
+
+      this.skipBuiltInComponents = !!config.skipBuiltInComponents;
     }
   }
 }
@@ -27,6 +30,12 @@ const HTML_ATTRIBUTES = [
   "class",
   "placeholder",
   "required"
+];
+
+const BUILT_IN_COMPONENTS = [
+  "link-to",
+  "input",
+  "textarea"
 ];
 
 /**
@@ -320,6 +329,11 @@ module.exports = function(fileInfo, api, options) {
 
   const transformNode = node => {
     const tagName = node.path.original;
+
+    if (config.skipBuiltInComponents && BUILT_IN_COMPONENTS.includes(tagName)) {
+      return;
+    }
+
     const newTagName = transformTagName(tagName);
 
     let attributes;


### PR DESCRIPTION
closes https://github.com/rajasegar/ember-angle-brackets-codemod/issues/43