### PR TITLE
Upgrade @glimmer/syntax and turn on `codemod` mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+#editors
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -807,25 +807,25 @@
       }
     },
     "@glimmer/interfaces": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.40.1.tgz",
-      "integrity": "sha512-gk+3Ij3hrJHPBJpCQE1wF54sh4M/NRx/JOJOhCzsyrf488IDnw2v93ZDEwBd7O3EcQDaRZMOQq6M3FNh/0YZpw=="
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.41.0.tgz",
+      "integrity": "sha512-d0Ryj8iV3FiyMyT4QpwHNg2QFFEmdzI5cJFcbmC+OmuTe6eOQ52mLDlw1+D+a3ZDv8Jfj3l0QkEcEugCxDY+1Q=="
     },
     "@glimmer/syntax": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.40.1.tgz",
-      "integrity": "sha512-lZ0xv9wNBVt1tteWszQy+PZbVi8v1vmlYjCTU9s/q2H1khrnVe6VYvicVapGATqlMQ84reRqJkQKdgfpy+ig6A==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.41.0.tgz",
+      "integrity": "sha512-sYmgUMdK0jX+3ZNX9C2TKvL1YZGsKIcXRicwnzoTC7F56z29CbSCc7o6Zf0CI4L2Q7FSnHDxldlSe48wBAr6vQ==",
       "requires": {
-        "@glimmer/interfaces": "^0.40.1",
-        "@glimmer/util": "^0.40.1",
+        "@glimmer/interfaces": "^0.41.0",
+        "@glimmer/util": "^0.41.0",
         "handlebars": "^4.0.13",
         "simple-html-tokenizer": "^0.5.7"
       }
     },
     "@glimmer/util": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.40.1.tgz",
-      "integrity": "sha512-YuV7hhjrPi/2YYc+GCyOBzrG1xSolQ4Fg/dkQdpDkTA03UkC9BiCQRxbOK4SjlV9IuBSEIv/Is6BOfkQ8hhX2g=="
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.41.0.tgz",
+      "integrity": "sha512-aKmQy62eRFhOZET9XmTB8MOA32G1FmD4d9HWL21OfdcGM4IbguRrWLMQc2DRh1YOE2AaT0PBrFrPmpNwFp5tpQ=="
     },
     "@jest/console": {
       "version": "24.7.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
   },
   "dependencies": {
-    "@glimmer/syntax": "^0.40.1",
+    "@glimmer/syntax": "^0.41.0",
     "codemod-cli": "^0.2.10",
     "prettier": "^1.17.0"
   },

--- a/transforms/angle-brackets/__testfixtures__/entities.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/entities.input.hbs
@@ -1,0 +1,2 @@
+&lt; &gt; &times;
+{{#foo data-a="&quot;Foo&nbsp;&amp;&nbsp;Bar&quot;"}}&nbsp;Some text &gt;{{/foo}}

--- a/transforms/angle-brackets/__testfixtures__/entities.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/entities.output.hbs
@@ -1,0 +1,4 @@
+&lt; &gt; &times;
+<Foo data-a="&quot;Foo&nbsp;&amp;&nbsp;Bar&quot;">
+  &nbsp;Some text &gt;
+</Foo>

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -222,7 +222,10 @@ const transformNestedSubExpression = subExpression => {
  * @returns {undefined}
  */
 module.exports = function(fileInfo, api, options) {
-  const ast = glimmer.preprocess(fileInfo.source);
+  const ast = glimmer.preprocess(fileInfo.source, {
+    mode: 'codemod',
+    parseOptions: { ignoreStandalone: true },
+  });
   const b = glimmer.builders;
   const config = new Config(options);
   


### PR DESCRIPTION
Fixes #48 

Updates `@glimmer/syntax` to 0.41.0 and turns on `codemod` mode. Also grabs the failing entities test from #49 

/cc @rwjblue @GavinJoyce 