### PR TITLE
fix expression with string literal param

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.input.hbs
@@ -11,7 +11,12 @@
 {{some-component person=(hash name="Sophie" age=1) message=(t "welcome" count=1)}}
 {{some-component
   people=(array
-    (hash name="Alex" age=5 nested=(hash oldest=true amount=(format-currency 350 sign="£")))
+    (hash
+      name="Alex"
+      age=5
+      nested=(hash oldest=true amount=(format-currency 350 sign="£"))
+      disabled=(eq foo "bar")
+    )
     (hash name="Ben" age=4)
     (hash name="Sophie" age=1)
   )

--- a/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/deeply-nested-sub.output.hbs
@@ -18,6 +18,7 @@
       name="Alex"
       age=5
       nested=(hash oldest=true amount=(format-currency 350 sign="£"))
+      disabled=(eq foo "bar")
     )
     (hash name="Ben" age=4)
     (hash name="Sophie" age=1)

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -189,6 +189,8 @@ const transformNestedSubExpression = subExpression => {
   let positionalArgs = subExpression.params.map(param => {
     if (param.type === "SubExpression") {
       return transformNestedSubExpression(param);
+    } else if (param.type === "StringLiteral") {
+      return `"${param.original}"`;
     } else {
       return param.original;
     }


### PR DESCRIPTION
I noticed that `disabled=(eq foo "bar")` was being transformed to ``disabled=(eq foo bar)`. This PR fixes that