### PR TITLE
Convert nested components which have no arguments

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/nested.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/nested.input.hbs
@@ -5,3 +5,4 @@
     {{#s.option value=country}}{{country.name}}{{/s.option}}
   {{/each}}
 {{/some-path/another-path/super-select}}
+{{x-foo/x-bar}}

--- a/transforms/angle-brackets/__testfixtures__/nested.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/nested.output.hbs
@@ -7,3 +7,4 @@
     </s.option>
   {{/each}}
 </SomePath::AnotherPath::SuperSelect>
+<XFoo::XBar />

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -155,6 +155,10 @@ const isAttribute = key => {
   return HTML_ATTRIBUTES.includes(key) || key.startsWith('data-');
 }
 
+const isNestedComponentTagName = tagName => {
+  return tagName && tagName.includes && tagName.includes('/');
+}
+
 /**
  *  Returns a capitalized tagname for angle brackets syntax
  *  {{my-component}} => MyComponent
@@ -173,7 +177,7 @@ const transformTagName = tagName => {
     return tagName;
   }
 
-  if (tagName.includes('/')) {
+  if (isNestedComponentTagName(tagName)) {
     return transformNestedTagName(tagName);
   }
 
@@ -394,7 +398,10 @@ module.exports = function(fileInfo, api, options) {
     MustacheStatement(node) {
       // Don't change attribute statements
       const isValidMustache = node.loc.source !== "(synthetic)" && !shouldIgnoreMustacheStatement(node.path.original);
-      if (isValidMustache && (node.hash.pairs.length > 0 || node.params.length > 0)) {
+      const tagName = node.path.original;
+      const isNestedComponent = isNestedComponentTagName(tagName);
+
+      if (isValidMustache && (node.hash.pairs.length > 0 || node.params.length > 0 || isNestedComponent)) {
         return transformNode(node);
       }
     },


### PR DESCRIPTION
This PR converts `{{x-foo/x-bar}}` into `<XFoo::XBar />`