### PR TITLE
fix inline `{{link-to}}` with dynamic first param

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/link-to-inline.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/link-to-inline.input.hbs
@@ -15,3 +15,9 @@
   current-when='apps.segments'
   data-test-segment-link='segments'
 }}
+{{link-to 
+  segment.name 
+  'apps.app.companies.segments.segment' 
+  segment 
+  class="t__em-link"
+}}

--- a/transforms/angle-brackets/__testfixtures__/link-to-inline.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/link-to-inline.output.hbs
@@ -19,3 +19,10 @@
 >
   Segments
 </LinkTo>
+<LinkTo
+  @route="apps.app.companies.segments.segment"
+  @model={{segment}}
+  class="t__em-link"
+>
+  {{segment.name}}
+</LinkTo> 

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -402,7 +402,12 @@ module.exports = function(fileInfo, api, options) {
         let textParam = params.shift(); //the first param becomes the block content
 
         attributes = transformLinkToAttrs(params);
-        children = [b.text(textParam.value)];
+
+        if (textParam.type === "PathExpression") {
+          children = [b.mustache(b.path(textParam.original))];
+        } else {
+          children = [b.text(textParam.value)];
+        }
       } else {
         attributes = transformLinkToAttrs(node.params);
       }


### PR DESCRIPTION
fixes the failing test provided in https://github.com/rajasegar/ember-angle-brackets-codemod/pull/68