### PR TITLE
skip components with positional params which are paths

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/positional-params.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/positional-params.input.hbs
@@ -2,5 +2,8 @@
 {{#some-component "foo"}}
   hi
 {{/some-component}}
+{{#some-component foo}}
+  hi
+{{/some-component}}
 {{some-component 123}}
 {{some-component (some-helper 987)}}

--- a/transforms/angle-brackets/__testfixtures__/positional-params.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/positional-params.output.hbs
@@ -2,5 +2,8 @@
 {{#some-component "foo"}}
   hi
 {{/some-component}}
+{{#some-component foo}}
+  hi
+{{/some-component}}
 {{some-component 123}}
 {{some-component (some-helper 987)}}

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -390,6 +390,10 @@ module.exports = function(fileInfo, api, options) {
 
       if (["StringLiteral", "NumberLiteral", "SubExpression"].includes(firstParamType)) {
         return true;
+      } else if (firstParamType === "PathExpression") {
+        if (!isAttribute(node.params[0].original)) {
+          return true;
+        }
       }
     }
 


### PR DESCRIPTION
this will skip components which have positional params like:

```hbs
{{#some-component foo}}
  hi
{{/some-component}}
```