### PR TITLE
add `with` as built-in keyword

### DIFF
--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -81,6 +81,7 @@ const IGNORE_MUSTACHE_STATEMENTS = [
   "debugger",
   "else",
   "let",
+  "with",
   "log",
   "loc",
   "hash",


### PR DESCRIPTION
Don't emit warnings for `with` keyword