### PR TITLE
convert yielded components which contain a `-`

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/sample2.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/sample2.input.hbs
@@ -3,4 +3,6 @@
   {{#card.content}}
     <p>hello</p>
   {{/card.content}}
+  {{card.foo-bar}}
+  {{card.foo}}
 {{/my-card}}

--- a/transforms/angle-brackets/__testfixtures__/sample2.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/sample2.output.hbs
@@ -5,4 +5,6 @@
       hello
     </p>
   </card.content>
+  <card.foo-bar />
+  {{card.foo}}
 </MyCard>

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -161,7 +161,7 @@ const isAttribute = key => {
 }
 
 const isNestedComponentTagName = tagName => {
-  return tagName && tagName.includes && tagName.includes('/');
+  return tagName && tagName.includes && (tagName.includes('/') || tagName.includes('-'));
 }
 
 /**


### PR DESCRIPTION
While `card.foo-bar` is ambiguous and could be a property, I think it's overwhelmingly likely to be a component.

This converts the following:

```hbs
{{#my-card as |card|}}
  {{card.foo-bar}}
  {{card.foo}}
{{/my-card}}
```

to:

```hbs
<MyCard as |card|>
  <card.foo-bar />
  {{card.foo}}
</MyCard>
```