### PR TITLE
Allow using a `.js` config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ npx ember-angle-brackets-codemod angle-brackets app/templates
 
 ### Skipping helpers
 
-To help the codemod disambiguate components and helpers, you can define a list of helpers from your application in a configuration file as follows:
+To help the codemod disambiguate components and helpers, you can define a list of helpers from your application in a configuration file as follows (`.json` and `.js` are supported):
 
 **config/anglebrackets-codemod-config.json**
 
@@ -66,6 +66,18 @@ To help the codemod disambiguate components and helpers, you can define a list o
   ]
 }
 ```
+
+**config/anglebrackets-codemod-config.js**
+
+```js
+module.exports = {
+  "helpers": [
+    "date-formatter", 
+    "info-pill"
+  ]
+}
+```
+
 The codemod will then ignore the above list of helpers and prevent them from being transformed into the new angle-brackets syntax.
 
 You can also disable the conversion of the built-in components `{{link-to}}`, `{{input}}` and `{{textarea}}` as follows:

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.config.js
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "helpers": ["some-helper1", "some-helper2", "some-helper3"],
+  "skipBuiltInComponents": true
+};

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.input.hbs
@@ -1,0 +1,6 @@
+{{some-component foo=true}}
+{{some-helper1 foo=true}}
+{{some-helper2 foo=true}}
+{{link-to "Title" "some.route"}}
+{{textarea value=this.model.body}}
+{{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.options.json
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.options.json
@@ -1,0 +1,3 @@
+{
+  "config": "./transforms/angle-brackets/__testfixtures__/custom-options-js.config.js"
+}

--- a/transforms/angle-brackets/__testfixtures__/custom-options-js.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/custom-options-js.output.hbs
@@ -1,0 +1,6 @@
+<SomeComponent @foo={{true}} />
+{{some-helper1 foo=true}}
+{{some-helper2 foo=true}}
+{{link-to "Title" "some.route"}}
+{{textarea value=this.model.body}}
+{{input type="checkbox" name="email-opt-in" checked=this.model.emailPreference}}

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -12,7 +12,7 @@ class Config {
 
     if (options.config) {
       let filePath = path.join(process.cwd(), options.config);
-      let config = JSON.parse(fs.readFileSync(filePath));
+      let config = this.getConfig(filePath);
 
       if (config.helpers) {
         this.helpers = config.helpers;
@@ -23,6 +23,14 @@ class Config {
       }
 
       this.skipBuiltInComponents = !!config.skipBuiltInComponents;
+    }
+  }
+
+  getConfig(filePath) {
+    if (filePath.endsWith('.js')) {
+      return require(filePath);
+    } else {
+      return JSON.parse(fs.readFileSync(filePath));
     }
   }
 }


### PR DESCRIPTION
I have a use case where I'd like to use a .js file as my configuration file.

In my case I have the list of application helpers as an exported node lib so I can reuse it in this codemod as well as some custom linting rules. This change enables that ability.