### PR TITLE
Fix issue where `link-to` model as string literal isn't converted correctly

### DIFF
--- a/transforms/angle-brackets/__testfixtures__/link-to-model.input.hbs
+++ b/transforms/angle-brackets/__testfixtures__/link-to-model.input.hbs
@@ -1,1 +1,2 @@
 {{#link-to "post" post}}Read {{post.title}}...{{/link-to}}
+{{#link-to "post" "string-id"}}Read {{post.title}}...{{/link-to}}

--- a/transforms/angle-brackets/__testfixtures__/link-to-model.output.hbs
+++ b/transforms/angle-brackets/__testfixtures__/link-to-model.output.hbs
@@ -3,3 +3,8 @@
   {{post.title}}
   ...
 </LinkTo>
+<LinkTo @route="post" @model="string-id">
+  Read
+  {{post.title}}
+  ...
+</LinkTo>

--- a/transforms/angle-brackets/transforms/angle-brackets-syntax.js
+++ b/transforms/angle-brackets/transforms/angle-brackets-syntax.js
@@ -362,7 +362,7 @@ module.exports = function(fileInfo, api, options) {
         let _queryParam = b.attr("@query", b.mustache(b.path("hash"), [], secondParamInput.hash));
         attributes = [firstParamOutput, _queryParam];
       } else {
-        let _modelParam = b.attr("@model", b.mustache(secondParamInput.original));
+        let _modelParam = b.attr("@model", transformModelParams(secondParamInput));
         attributes = [firstParamOutput, _modelParam];
       }
     } else if (params.length > 2) {


### PR DESCRIPTION
This PR fixes an issue where having a `link-to` model as a string literal isn't converted correctly.

### Before
```hbs
{{#link-to "post" "string-id"}}Read {{post.title}}...{{/link-to}}
```

### After (broken)
```hbs
<LinkTo @route="post" @model={{string-id}}>
  Read
  {{post.title}}
  ...
</LinkTo>
```

### With fix
```hbs
<LinkTo @route="post" @model="string-id">
  Read
  {{post.title}}
  ...
</LinkTo>
```